### PR TITLE
Fix for Ubuntu 20.04 on Hyper-V

### DIFF
--- a/lib/guest_config.rb
+++ b/lib/guest_config.rb
@@ -36,7 +36,7 @@ module GuestConfig
           nameservers:
             addresses: [%<dns1>s, %<dns2>s]
   DOC
-  @network[:apply_cmd][:ubuntu] = 'sudo netplan apply'
+  @network[:apply_cmd][:ubuntu] = 'sudo netplan apply &'
 
   module_function
 


### PR DESCRIPTION
Run 'netplan apply' in the background to avoid hanging (before virtual switch is changed from the default to NAT).